### PR TITLE
Add simple parser error reporting

### DIFF
--- a/include/error_reporter.h
+++ b/include/error_reporter.h
@@ -1,0 +1,10 @@
+#ifndef ERROR_REPORTER_H
+#define ERROR_REPORTER_H
+
+void error_reporter_init();
+void error_reporter_add(const char *msg);
+void error_reporter_print();
+int error_reporter_has_errors();
+void error_reporter_free();
+
+#endif // ERROR_REPORTER_H

--- a/src/error_reporter.c
+++ b/src/error_reporter.c
@@ -1,0 +1,59 @@
+#include "error_reporter.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct ErrorNode {
+    char *msg;
+    struct ErrorNode *next;
+} ErrorNode;
+
+static ErrorNode *head = NULL;
+static ErrorNode *tail = NULL;
+static int error_count = 0;
+
+void error_reporter_init() {
+    head = tail = NULL;
+    error_count = 0;
+}
+
+void error_reporter_add(const char *msg) {
+    ErrorNode *node = (ErrorNode *)malloc(sizeof(ErrorNode));
+    if (!node) {
+        perror("malloc");
+        exit(1);
+    }
+    node->msg = strdup(msg);
+    node->next = NULL;
+    if (!head) {
+        head = tail = node;
+    } else {
+        tail->next = node;
+        tail = node;
+    }
+    error_count++;
+}
+
+void error_reporter_print() {
+    ErrorNode *cur = head;
+    while (cur) {
+        fprintf(stderr, "%s\n", cur->msg);
+        cur = cur->next;
+    }
+}
+
+int error_reporter_has_errors() {
+    return error_count > 0;
+}
+
+void error_reporter_free() {
+    ErrorNode *cur = head;
+    while (cur) {
+        ErrorNode *next = cur->next;
+        free(cur->msg);
+        free(cur);
+        cur = next;
+    }
+    head = tail = NULL;
+    error_count = 0;
+}

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,4 +1,5 @@
 #include "lexer.h"
+#include "error_reporter.h"
 
 // 判断字符串是否为关键字
 static int is_keyword(const char* str) {
@@ -88,6 +89,9 @@ Token get_next_token(FILE* file) {
 
     // 未知字符
     else {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "Unknown token: %c", c);
+        error_reporter_add(msg);
         token.value[0] = c;
         token.value[1] = '\0';
         token.type = TOKEN_UNKNOWN;

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "lexer.h"
 #include "parser.h"
+#include "error_reporter.h"
 
 void print_ast(ASTNode* node, int level) {
     if (node == NULL) return;
@@ -38,6 +39,8 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    error_reporter_init();
+
     // 词法分析
     printf("=== Lexical Analysis ===\n");
     Token token;
@@ -55,11 +58,16 @@ int main(int argc, char* argv[]) {
     init_parser(&parser, file);
 
     ASTNode* ast = parse(&parser);
-    printf("\n=== Abstract Syntax Tree ===\n");
-    print_ast(ast, 0);
+
+    if (!error_reporter_has_errors()) {
+        printf("\n=== Abstract Syntax Tree ===\n");
+        print_ast(ast, 0);
+    }
 
     // 释放资源
     free_ast(ast);
+    error_reporter_print();
+    error_reporter_free();
     fclose(file);
     return 0;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,11 +1,16 @@
 #include "parser.h"
+#include "error_reporter.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 // 解析错误处理
 static void parser_error(const char* message) {
-    fprintf(stderr, "Parser Error: %s\n", message);
+    char msg[256];
+    snprintf(msg, sizeof(msg), "Parser Error: %s", message);
+    error_reporter_add(msg);
+    error_reporter_print();
+    error_reporter_free();
     exit(1);
 }
 


### PR DESCRIPTION
## Summary
- collect error messages during lexing and parsing
- output parser errors using new error_reporter module
- stop parsing with message when encountering errors

## Testing
- `cmake ..`
- `cmake --build .`
- `./minic ../input.minic`
- `./minic ../bad.minic`

------
https://chatgpt.com/codex/tasks/task_e_684434f0660483319a991635fbb4ebc0